### PR TITLE
Fix issue with reading large nfs files

### DIFF
--- a/src/main/java/com/sun/nfs/Buffer.java
+++ b/src/main/java/com/sun/nfs/Buffer.java
@@ -91,7 +91,7 @@ public class Buffer extends Thread {
     final static int DIRTY  = 2;	// Has new data
     final static int COMMIT = 3;	// Not committed
 
-    public Buffer(Nfs nfs, int foffset, int bufsize) {
+    public Buffer(Nfs nfs, long foffset, int bufsize) {
         this.nfs = nfs;
         this.foffset = foffset;
         this.bufsize = bufsize;
@@ -144,7 +144,7 @@ public class Buffer extends Thread {
      
         int off = (int) (foffset - this.foffset);
         int copylen = Math.min(length, buflen - off);
-        copylen = Math.min(copylen, (int) (nfs.length() - foffset));
+        copylen = (int) Math.min((long)copylen, nfs.length() - foffset);
 
         System.arraycopy(buf, bufoff + off, buff, boff, copylen);
 

--- a/src/main/java/com/sun/nfs/Nfs.java
+++ b/src/main/java/com/sun/nfs/Nfs.java
@@ -251,12 +251,12 @@ public abstract class Nfs {
              * to for the entire file.
              */
             if (bufferList == null)
-                bufferList = new Buffer[(int) length() / rsize + 1];
+                bufferList = new Buffer[(int) (length() / rsize + 1)];
 
 	    /*
 	     * Find the block that holds the data
 	     */
-            index = (int) foffset / rsize;
+            index = (int) (foffset / rsize);
             if (index > maxIndexRead)
                 maxIndexRead = index;
 
@@ -298,7 +298,7 @@ public abstract class Nfs {
 
                 b = bufferList[n];
                 if (b == null) {
-                    b = new Buffer(this, n * rsize, rsize);
+                    b = new Buffer(this, (long) n * (long) rsize, rsize);
                     b.startLoad();
                     bufferList[n] = b;
                 }
@@ -324,7 +324,7 @@ public abstract class Nfs {
                 if (n.error == 72) { // DEC's EBADRPC
                     rsize = 8192;
                     bufferList = 
-                        new Buffer[(int) length() / rsize + 1];
+                        new Buffer[(int)(length() / rsize + 1)];
                     continue;
                 }
 
@@ -349,7 +349,7 @@ public abstract class Nfs {
 	    /*
 	     * Copy data from the file buffer into the application buffer.
 	     */
-            int cc = b.copyFrom(buf, boff, foffset, length);
+            int cc = b.copyFrom(buf, boff, foffset,length);
 
             boff += cc;
             foffset += cc;
@@ -422,7 +422,7 @@ public abstract class Nfs {
          */
         if (bufferList == null) {
             long fileSize = Math.max(length(), 50 * wsize);
-            bufferList = new Buffer[(int) fileSize / wsize + 1];
+            bufferList = new Buffer[(int)(fileSize / wsize + 1)];
         }
 
         /*
@@ -443,7 +443,7 @@ public abstract class Nfs {
 	 */
         while (length > 0) {
 
-            int index = (int) foffset / wsize;
+            int index = (int)(foffset / wsize);
 
             /*
              * If writing into a new buffer


### PR DESCRIPTION
When reading large NFS  files(>2.5GB) it fails with java.lang.NegativeArraySizeException
This is mainly because of the lossy type cast between long and int.
This diff introduces the change to cast the variables correctly so that the conversion is not lossy.

**Testing**
Verified the fix by copying a 3.5GB file and it worked fine.