### PR TITLE
fix: use public API in MimeTable for Java 25 compatibility

### DIFF
--- a/src/main/java/com/sun/xhandler/NfsURLConnection.java
+++ b/src/main/java/com/sun/xhandler/NfsURLConnection.java
@@ -231,9 +231,11 @@ public class NfsURLConnection extends URLConnection {
 		        String imageFileName = MimeEntry_defaultImagePath + "/file.gif";
 
 		        // Find the file image to use using the file's .suffix
-		        entry = mt.findByFileName(dirList[i]);
-		        if (entry != null) {
-			    String realImageName = entry.getImageFileName();
+		        String mimeType = mt.getContentTypeFor(dirList[i]);
+
+		        if (mimeType != null) {
+			    String realImageName = MimeEntry_defaultImagePath +
+			        "/" + mimeType.replace('/', '-') + ".gif";
 			    if (realImageName != null) {
 			        imageFileName = realImageName;
 			    }
@@ -267,9 +269,9 @@ public class NfsURLConnection extends URLConnection {
         } else {
             // Mark the input stream we return as containing a certain file type
             // by looking up the file name in the mimetable 
-            entry = mt.findByFileName(path);
-            if (entry != null) {
-                props.add("content-type", entry.getType());
+            String contentType = mt.getContentTypeFor(path);
+            if (contentType != null) {
+                props.add("content-type", contentType);
             } 
             setProperties(props);
             


### PR DESCRIPTION
 MimeTable.findByFileName is no longer public in MimeTable.
 MimeTable has no public methods to access MimeEntry.
 Use public API to get the content type and compose icon file 
 name based on the content type.

This may introduce incompatibility due to the change in the file name, but there is no public API to retrieve the icon name in Java 25 as far as I am aware.